### PR TITLE
ci: unblock Lint job (Go version mismatch between runtime build & go.mod target)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          # Pin to v1.64.8 (last v1 release) to pair with the v1-format
+          # .golangci.yml. `latest` can drift to v2 and fail config parsing.
+          version: v1.64.8
           args: --timeout=5m
           skip-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,10 @@ run:
   timeout: 5m
   tests: true
   # Cache bust: 2025-08-15
+  # Pin lint target to Go 1.24 so the analyser (built against Go 1.24 in
+  # golangci-lint v1.64.x) does not bail out on go.mod's 1.26.1 directive.
+  # Remove once golangci-lint ships a Go 1.26 binary and we can migrate to v2.
+  go: "1.24"
 
 linters:
   enable:


### PR DESCRIPTION
## Problem

Master's `Lint` job has been failing every run with:

```
Error: can't load config: the Go language version (go1.24) used to
build golangci-lint is lower than the targeted Go version (1.26.1)
Failed executing command with error: can't load config: the Go
language version (go1.24) used to build golangci-lint is lower than
the targeted Go version (1.26.1)
##[error]golangci-lint exit with code 3
```

Example failing run: https://github.com/luxfi/threshold/actions/runs/24754524639

## Root cause

`.github/workflows/ci.yml` runs:

```yaml
uses: golangci/golangci-lint-action@v6
with:
  version: latest
```

The action resolves `latest` to **golangci-lint v1.64.8**, which is the
last v1 release. That binary is published as a pre-built artifact
compiled with **Go 1.24**. Our `go.mod` targets **Go 1.26.1**.

golangci-lint's config loader calls `goutil.CheckGoVersion`, which
compares the runtime Go version (from `runtime.Version()` of the
binary itself) against the target Go version inferred from `go.mod`.
Since `1.24 < 1.26.1`, it refuses to load the config and exits.

golangci-lint v2.x would help (v2.11.4 is built with Go 1.25), but
moving to v2 requires migrating `.golangci.yml` to the v2 schema
(`version: "2"` + restructured `linters`/`formatters`/`issues` blocks).
That is a bigger, separate change.

## Fix (minimal)

1. **`.golangci.yml`** — add `run.go: "1.24"` so the version check sees
   a target equal to the build version and proceeds. The linter then
   runs normally; we lose Go 1.26-specific language analysis but keep
   all vet/staticcheck/etc. working.
2. **`.github/workflows/ci.yml`** — pin
   `golangci/golangci-lint-action@v6` to `version: v1.64.8` explicitly.
   Today our v1 config would break if `latest` ever drifts onto v2, so
   let's pin until we're ready to migrate.

```diff
 run:
   timeout: 5m
   tests: true
   # Cache bust: 2025-08-15
+  # Pin lint target to Go 1.24 so the analyser (built against Go 1.24 in
+  # golangci-lint v1.64.x) does not bail out on go.mod's 1.26.1 directive.
+  # Remove once golangci-lint ships a Go 1.26 binary and we can migrate to v2.
+  go: "1.24"
```

```diff
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          # Pin to v1.64.8 (last v1 release) to pair with the v1-format
+          # .golangci.yml. `latest` can drift to v2 and fail config parsing.
+          version: v1.64.8
```

No source code changes. Workflow- and lint-config-only.

## Why this unblocks us

Three docs PRs are currently UNSTABLE purely because of this master
lint failure, not because of anything they introduce:

- #6 — docs: consolidate root markdown
- #7 — docs: fix broken links
- #8 — docs/audit-md

Once this merges and `main` is green, those PRs should go green on
re-run (or after a trivial rebase).

## Follow-ups (not this PR)

- `Test (macos)` is separately flaky and deserves its own
  investigation.
- Migrate `.golangci.yml` to v2 schema and bump the action to `@v8`
  once golangci-lint ships a build against Go 1.26 (then we can drop
  the `run.go` pin).

— [kcolbchain](https://kcolbchain.com) / [Abhishek Krishna](https://abhishekkrishna.com)